### PR TITLE
Improve dependency checks for providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ url = create_github_issue("user/repo", "Test failed", "Details...", "token")
 
 ## Troubleshooting
 - **Import errors:** Ensure you're in your virtual environment and have run `pip install -e .`.
+- **Missing dependencies:** If you see errors about `openai` or `PyGithub` not being installed, run `pip install openai PyGithub`.
 - **API key issues:** Run `testpilot reset-keys` to re-enter keys.
 - **Permission errors:** Make sure your GitHub token has `repo` scope for issue creation.
 - **Test failures:** Check the generated test file and your source code for errors.

--- a/testpilot/core.py
+++ b/testpilot/core.py
@@ -4,8 +4,10 @@ from testpilot.llm_providers import get_llm_provider
 
 try:
     from github import Github
+    PYGITHUB_AVAILABLE = True
 except ImportError:
     Github = None
+    PYGITHUB_AVAILABLE = False
 
 def generate_tests_llm(source_file, provider_name, model_name, api_key=None):
     """
@@ -69,11 +71,12 @@ def run_pytest_tests(test_file, return_trace=False):
             return error_msg
 
 def create_github_issue(repo, title, body, github_token):
-    """
-    Creates a GitHub issue and returns the issue URL.
-    """
-    if Github is None:
-        raise ImportError("PyGithub is not installed. Please install it to use GitHub integration.")
+    """Creates a GitHub issue and returns the issue URL."""
+    if not PYGITHUB_AVAILABLE:
+        raise ImportError(
+            "PyGithub is required for GitHub issue creation. "
+            "Install it with 'pip install PyGithub'."
+        )
     
     if not github_token:
         raise ValueError("GitHub token is required for creating issues.")

--- a/testpilot/llm_providers.py
+++ b/testpilot/llm_providers.py
@@ -3,8 +3,10 @@ import os
 
 try:
     from openai import OpenAI
+    OPENAI_AVAILABLE = True
 except ImportError:
     OpenAI = None
+    OPENAI_AVAILABLE = False
 
 class LLMProvider(ABC):
     @abstractmethod
@@ -13,8 +15,11 @@ class LLMProvider(ABC):
 
 class OpenAIProvider(LLMProvider):
     def __init__(self, api_key: str = None):
-        if OpenAI is None:
-            raise ImportError("openai package is not installed.")
+        if not OPENAI_AVAILABLE:
+            raise ImportError(
+                "The 'openai' package is required for the OpenAI provider. "
+                "Install it with 'pip install openai'."
+            )
         self.api_key = api_key or os.environ.get("OPENAI_API_KEY")
         if not self.api_key:
             raise ValueError("OpenAI API key must be provided via argument or OPENAI_API_KEY env var.")
@@ -37,6 +42,11 @@ class OpenAIProvider(LLMProvider):
 
 def get_llm_provider(provider_name: str, api_key: str = None) -> LLMProvider:
     if provider_name.lower() == "openai":
+        if not OPENAI_AVAILABLE:
+            raise ImportError(
+                "The 'openai' package is required for the OpenAI provider. "
+                "Install it with 'pip install openai'."
+            )
         return OpenAIProvider(api_key)
     # Future: add elif for other providers (Anthropic, Ollama, etc.)
-    raise ValueError(f"Unsupported LLM provider: {provider_name}") 
+    raise ValueError(f"Unsupported LLM provider: {provider_name}")


### PR DESCRIPTION
## Summary
- detect `PyGithub` availability in `core.py` and give install hint
- check for `openai` installation in `llm_providers.py` and fail gracefully
- document dependency errors in the troubleshooting guide

## Testing
- `pytest -q`
- `pip check`

------
https://chatgpt.com/codex/tasks/task_e_68703c3bc004832eaa19b302d40288bf