### PR TITLE
Implement provider registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ url = create_github_issue("user/repo", "Test failed", "Details...", "token")
 - **GitHub Actions:** See `.github/workflows/testpilot_ci.yml` for CI integration.
 - **Extensible:** Add new LLM providers or plugins via `llm_providers.py` and future plugin hooks.
 
+### Adding a New LLM Provider
+1. Subclass `LLMProvider` and implement `generate_text`.
+2. Register the class with `@register_provider("your_name")`.
+3. Optionally place the class in another module and use `get_llm_provider("module.ClassName")` to load it dynamically.
+
 ## Troubleshooting
 - **Import errors:** Ensure you're in your virtual environment and have run `pip install -e .`.
 - **API key issues:** Run `testpilot reset-keys` to re-enter keys.

--- a/testpilot/llm_providers.py
+++ b/testpilot/llm_providers.py
@@ -1,23 +1,38 @@
 from abc import ABC, abstractmethod
 import os
+import importlib
 
-try:
-    from openai import OpenAI
-except ImportError:
-    OpenAI = None
+PROVIDER_REGISTRY = {}
+
+
+def register_provider(name: str):
+    """Decorator to register an LLM provider class by name."""
+
+    def _wrapper(cls):
+        PROVIDER_REGISTRY[name.lower()] = cls
+        return cls
+
+    return _wrapper
+
 
 class LLMProvider(ABC):
     @abstractmethod
     def generate_text(self, prompt: str, model_name: str) -> str:
         pass
 
+
+@register_provider("openai")
 class OpenAIProvider(LLMProvider):
     def __init__(self, api_key: str = None):
-        if OpenAI is None:
-            raise ImportError("openai package is not installed.")
+        try:
+            from openai import OpenAI
+        except ImportError as exc:
+            raise ImportError("openai package is not installed.") from exc
         self.api_key = api_key or os.environ.get("OPENAI_API_KEY")
         if not self.api_key:
-            raise ValueError("OpenAI API key must be provided via argument or OPENAI_API_KEY env var.")
+            raise ValueError(
+                "OpenAI API key must be provided via argument or OPENAI_API_KEY env var."
+            )
         self.client = OpenAI(api_key=self.api_key)
 
     def generate_text(self, prompt: str, model_name: str) -> str:
@@ -25,18 +40,38 @@ class OpenAIProvider(LLMProvider):
             model=model_name,
             messages=[
                 {"role": "system", "content": "You are an expert software engineer."},
-                {"role": "user", "content": prompt}
-            ]
+                {"role": "user", "content": prompt},
+            ],
         )
         content = chat_completion.choices[0].message.content
-        # Extract code block if present
         if "```python" in content:
-            content = content.split("```python")[1]
-            content = content.split("```", 1)[0]
+            content = content.split("```python")[1].split("```", 1)[0]
         return content.strip()
 
+
+@register_provider("anthropic")
+class AnthropicProvider(LLMProvider):
+    """Stub provider for Anthropic's Claude models."""
+
+    def __init__(self, api_key: str = None):
+        self.api_key = api_key or os.environ.get("ANTHROPIC_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "Anthropic API key must be provided via argument or ANTHROPIC_API_KEY env var."
+            )
+
+    def generate_text(self, prompt: str, model_name: str) -> str:
+        return "Anthropic provider is not yet implemented"
+
+
 def get_llm_provider(provider_name: str, api_key: str = None) -> LLMProvider:
-    if provider_name.lower() == "openai":
-        return OpenAIProvider(api_key)
-    # Future: add elif for other providers (Anthropic, Ollama, etc.)
-    raise ValueError(f"Unsupported LLM provider: {provider_name}") 
+    """Return an instance of a registered LLM provider."""
+
+    provider_cls = PROVIDER_REGISTRY.get(provider_name.lower())
+    if provider_cls is None and "." in provider_name:
+        module_name, class_name = provider_name.rsplit(".", 1)
+        module = importlib.import_module(module_name)
+        provider_cls = getattr(module, class_name)
+    if provider_cls is None:
+        raise ValueError(f"Unsupported LLM provider: {provider_name}")
+    return provider_cls(api_key)


### PR DESCRIPTION
## Summary
- add dynamic provider registry to `llm_providers` with stub Anthropic provider
- document how to register new providers in README

## Testing
- `pip install -e .`
- `python -m testpilot.cli --help`

------
https://chatgpt.com/codex/tasks/task_e_68703c3c86ac832e8eab380b2dc14516