### PR TITLE
Add linting config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+        args: [--check]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.3
+    hooks:
+      - id: ruff

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,17 @@ Thank you for your interest in contributing to TestPilot! We welcome contributio
 - Add docstrings to public functions
 - Keep functions focused and small
 
+## Linting
+
+We use `pre-commit` to run `black` and `ruff` (a fast flake8 replacement).
+Install the hooks once and run them manually with:
+
+```bash
+pip install pre-commit
+pre-commit install
+pre-commit run --all-files
+```
+
 ## Questions?
 
 - Open an issue for bugs or feature requests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,4 +42,18 @@ testpilot = "testpilot.cli:cli"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["testpilot*"] 
+include = ["testpilot*"]
+
+[tool.black]
+line-length = 88
+target-version = ['py37']
+
+[tool.ruff]
+line-length = 88
+target-version = "py37"
+select = ["E", "F", "I"]
+exclude = ["testpilot.egg-info"]
+
+[tool.flake8]
+max-line-length = 88
+extend-ignore = ["E203"]


### PR DESCRIPTION
## Summary
- configure Black, Ruff and flake8 in pyproject
- add `.pre-commit-config.yaml`
- document linting instructions in CONTRIBUTING

## Testing
- `pre-commit run --all-files` *(fails: would reformat files)*
- `pre-commit run --files pyproject.toml CONTRIBUTING.md .pre-commit-config.yaml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68703c3dbcfc832eaa877a9b1352bcac