### PR TITLE
Add docs and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ url = create_github_issue("user/repo", "Test failed", "Details...", "token")
 - **Console script issues:** If `testpilot` command doesn't work, use `python -m testpilot.cli` instead.
 
 ## Additional Resources
-- [Project Wiki](./docs/)
+- [Documentation](./docs/)
 - [Examples](./examples/)
 - [Contributing Guide](./CONTRIBUTING.md)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,6 @@
+# TestPilot Documentation
+
+This folder contains extended documentation for TestPilot.
+
+- [Usage Guide](./usage.md) – step-by-step instructions for using the CLI and API.
+- [Architecture Overview](./architecture.md) – explains the project structure and extension points.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,20 @@
+# Architecture Overview
+
+TestPilot is organized as a lightweight CLI application with a modular core.
+
+```
+cli.py       - command line interface using Click
+core.py      - high level operations for generating, running and triaging tests
+llm_providers.py - abstraction layer for different LLM backends
+```
+
+The CLI commands are thin wrappers around the functions in `core.py`. Those functions in turn rely on pluggable LLM providers defined in `llm_providers.py`.
+
+## Adding providers
+New language model providers can be added by implementing the `LLMProvider` abstract class and exposing a factory in `get_llm_provider`.
+
+## Generated tests
+Tests are written out to the `generated_tests/` directory so that you can review them before running.
+
+## GitHub integration
+When triaging failures, TestPilot uses `PyGithub` to open issues in your repository. This requires a token with `repo` scope.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,47 @@
+# Usage Guide
+
+This document provides a more in‑depth look at how to use **TestPilot** in day‑to‑day development.
+
+## Setup
+
+1. Install the package in editable mode:
+   ```bash
+   pip install -e .
+   ```
+2. Run the CLI once to enter your OpenAI and GitHub tokens:
+   ```bash
+   testpilot reset-keys
+   ```
+   Your keys are stored in a local `.env` file and never committed.
+
+## Generating tests
+
+Use the `generate` command to create pytest files from your source code:
+```bash
+testpilot generate path/to/your_module.py
+```
+The generated test file is saved in `generated_tests/` by default.
+
+## Running tests
+
+Run generated tests with the `run` command:
+```bash
+testpilot run generated_tests/test_your_module.py
+```
+
+## Triaging failures
+
+After running tests you can automatically open GitHub issues for failures:
+```bash
+testpilot triage generated_tests/test_your_module.py --repo youruser/yourrepo
+```
+
+## Advanced options
+
+- Use `--provider` and `--model` to select the LLM backend.
+- Use `--output-dir` to place tests in a custom folder.
+- Call the Python API directly for custom workflows:
+  ```python
+  from testpilot import generate_tests_llm
+  code = generate_tests_llm("my_module.py", "openai", "gpt-4o")
+  ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,5 @@
+# Example Projects
+
+This directory provides hands-on examples for using TestPilot.
+
+- [`sample_project`](./sample_project/) – a tiny project demonstrating how to generate and run tests.

--- a/examples/sample_project/README.md
+++ b/examples/sample_project/README.md
@@ -1,0 +1,25 @@
+# Sample Project
+
+This example shows how TestPilot fits into a small Python project.
+
+## Files
+- `calculator.py` – simple functions that we want to test.
+
+## Steps
+1. From the project root, install TestPilot in editable mode:
+   ```bash
+   pip install -e .
+   ```
+2. Generate tests for the calculator module:
+   ```bash
+   testpilot generate examples/sample_project/calculator.py
+   ```
+   This creates `generated_tests/test_calculator.py`.
+3. Run the generated tests:
+   ```bash
+   testpilot run generated_tests/test_calculator.py
+   ```
+4. Triage any failures to GitHub (requires token):
+   ```bash
+   testpilot triage generated_tests/test_calculator.py --repo youruser/yourrepo
+   ```

--- a/examples/sample_project/calculator.py
+++ b/examples/sample_project/calculator.py
@@ -1,0 +1,8 @@
+"""Simple math utility functions used by the example project."""
+
+def add(a, b):
+    return a + b
+
+
+def subtract(a, b):
+    return a - b


### PR DESCRIPTION
## Summary
- create `docs/` with usage guide and architecture notes
- add `examples/` with a sample project
- update README links to the new directories

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68703c42ff74832e9e5a01c5cf885b3b