### PR TITLE
Cleanup and style fixes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203

--- a/my_module.py
+++ b/my_module.py
@@ -1,5 +1,13 @@
-def add(a, b):
+"""Example module with basic math functions."""
+
+
+def add(a: int, b: int) -> int:
+    """Return the sum of ``a`` and ``b``."""
+
     return a + b
 
-def subtract(a, b):
-    return a - b 
+
+def subtract(a: int, b: int) -> int:
+    """Return the difference of ``a`` and ``b``."""
+
+    return a - b

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
-from setuptools import setup, find_packages
 import os
+
+from setuptools import find_packages, setup
+
 
 # Read version from package
 def get_version():
@@ -17,7 +19,9 @@ with open('README.md', 'r', encoding='utf-8') as f:
 setup(
     name='testpilot',
     version=get_version(),
-    description='AI-powered test generation, execution, and triage CLI for Python projects',
+    description=(
+        'AI-powered test generation, execution, and triage CLI for Python projects'
+    ),
     long_description=long_description,
     long_description_content_type='text/markdown',
     author='TestPilot Authors',

--- a/testpilot/__init__.py
+++ b/testpilot/__init__.py
@@ -5,12 +5,12 @@ TestPilot: AI-powered test generation, execution, and triage CLI for Python proj
 __version__ = "0.1.0"
 __author__ = "TestPilot Authors"
 
-from .core import generate_tests_llm, run_pytest_tests, create_github_issue
+from .core import create_github_issue, generate_tests_llm, run_pytest_tests
 from .llm_providers import get_llm_provider
 
 __all__ = [
     "generate_tests_llm",
-    "run_pytest_tests", 
+    "run_pytest_tests",
     "create_github_issue",
-    "get_llm_provider"
-] 
+    "get_llm_provider",
+]

--- a/testpilot/cli.py
+++ b/testpilot/cli.py
@@ -1,8 +1,14 @@
-import click
 import os
 from pathlib import Path
+
+import click
 from dotenv import load_dotenv, set_key
-from testpilot.core import generate_tests_llm, run_pytest_tests, create_github_issue
+
+from testpilot.core import (
+    create_github_issue,
+    generate_tests_llm,
+    run_pytest_tests,
+)
 
 ENV_PATH = Path(".env")
 ONBOARD_FLAG = Path(".testpilot_onboarded")
@@ -88,11 +94,22 @@ def help():
     print(HELP_TEXT)
 
 @cli.command()
-@click.argument('source_file', type=click.Path(exists=True, dir_okay=False, readable=True))
+@click.argument(
+    'source_file',
+    type=click.Path(exists=True, dir_okay=False, readable=True),
+)
 @click.option('--provider', default='openai', help='LLM provider (default: openai)')
 @click.option('--model', default='gpt-4o', help='Model name (default: gpt-4o)')
-@click.option('--api-key', default=None, help='API key for LLM provider (default: env var)')
-@click.option('--output-dir', default='./generated_tests', help='Directory to save generated tests')
+@click.option(
+    '--api-key',
+    default=None,
+    help='API key for LLM provider (default: env var)',
+)
+@click.option(
+    '--output-dir',
+    default='./generated_tests',
+    help='Directory to save generated tests',
+)
 def generate(source_file, provider, model, api_key, output_dir):
     """
     Generate unit tests for a SOURCE_FILE using an LLM.
@@ -106,7 +123,10 @@ def generate(source_file, provider, model, api_key, output_dir):
     click.echo(f"[generate] Test file written to {test_file}")
 
 @cli.command()
-@click.argument('test_file', type=click.Path(exists=True, dir_okay=False, readable=True))
+@click.argument(
+    'test_file',
+    type=click.Path(exists=True, dir_okay=False, readable=True),
+)
 def run(test_file):
     """
     Run tests in TEST_FILE using pytest.
@@ -115,7 +135,10 @@ def run(test_file):
     click.echo(result)
 
 @cli.command()
-@click.argument('test_file', type=click.Path(exists=True, dir_okay=False, readable=True))
+@click.argument(
+    'test_file',
+    type=click.Path(exists=True, dir_okay=False, readable=True),
+)
 @click.option('--repo', required=True, help='GitHub repo (e.g. user/repo)')
 def triage(test_file, repo):
     """
@@ -124,7 +147,12 @@ def triage(test_file, repo):
     result, failed, trace = run_pytest_tests(test_file, return_trace=True)
     click.echo(result)
     if failed:
-        url = create_github_issue(repo, f"Test failure in {test_file}", trace, os.getenv("GITHUB_TOKEN"))
+        url = create_github_issue(
+            repo,
+            f"Test failure in {test_file}",
+            trace,
+            os.getenv("GITHUB_TOKEN"),
+        )
         click.echo(f"[triage] Issue created: {url}")
     else:
         click.echo("[triage] All tests passed. No issue created.")

--- a/testpilot/core.py
+++ b/testpilot/core.py
@@ -1,11 +1,13 @@
 import os
 import subprocess
+
 from testpilot.llm_providers import get_llm_provider
 
 try:
     from github import Github
 except ImportError:
     Github = None
+
 
 def generate_tests_llm(source_file, provider_name, model_name, api_key=None):
     """
@@ -50,7 +52,7 @@ def run_pytest_tests(test_file, return_trace=False):
             ['python', '-m', 'pytest', test_file, '-v'],
             capture_output=True,
             text=True,
-            cwd=os.getcwd()
+            cwd=os.getcwd(),
         )
         
         output = result.stdout + result.stderr
@@ -73,7 +75,9 @@ def create_github_issue(repo, title, body, github_token):
     Creates a GitHub issue and returns the issue URL.
     """
     if Github is None:
-        raise ImportError("PyGithub is not installed. Please install it to use GitHub integration.")
+        raise ImportError(
+            "PyGithub is not installed. Please install it to use GitHub integration."
+        )
     
     if not github_token:
         raise ValueError("GitHub token is required for creating issues.")
@@ -91,4 +95,4 @@ def create_github_issue(repo, title, body, github_token):
         return issue.html_url
         
     except Exception as e:
-        raise Exception(f"Failed to create GitHub issue: {str(e)}") 
+        raise Exception(f"Failed to create GitHub issue: {str(e)}")

--- a/testpilot/llm_providers.py
+++ b/testpilot/llm_providers.py
@@ -1,6 +1,6 @@
-from abc import ABC, abstractmethod
-import os
 import importlib
+import os
+from abc import ABC, abstractmethod
 
 PROVIDER_REGISTRY = {}
 
@@ -31,7 +31,8 @@ class OpenAIProvider(LLMProvider):
         self.api_key = api_key or os.environ.get("OPENAI_API_KEY")
         if not self.api_key:
             raise ValueError(
-                "OpenAI API key must be provided via argument or OPENAI_API_KEY env var."
+                "OpenAI API key must be provided via argument or "
+                "OPENAI_API_KEY env var."
             )
         self.client = OpenAI(api_key=self.api_key)
 
@@ -57,7 +58,8 @@ class AnthropicProvider(LLMProvider):
         self.api_key = api_key or os.environ.get("ANTHROPIC_API_KEY")
         if not self.api_key:
             raise ValueError(
-                "Anthropic API key must be provided via argument or ANTHROPIC_API_KEY env var."
+                "Anthropic API key must be provided via argument or "
+                "ANTHROPIC_API_KEY env var."
             )
 
     def generate_text(self, prompt: str, model_name: str) -> str:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,8 +1,3 @@
-import os
-from pathlib import Path
-
-import pytest
-
 from testpilot.core import generate_tests_llm, run_pytest_tests
 
 


### PR DESCRIPTION
## Summary
- add flake8 config for consistent linting
- document example module
- reformat CLI and core modules
- shorten provider error messages
- clean up unit tests

## Testing
- `ruff check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687042edce00832eb5b988c8ab3a10d8