### PR TITLE
Fix unit test issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "PyGithub",
     "pytest",
     "python-dotenv",
+    "anthropic",
 ]
 
 [project.urls]

--- a/tests/test_enhanced_core.py
+++ b/tests/test_enhanced_core.py
@@ -279,7 +279,7 @@ class TestEnhancedLLMProviders(unittest.TestCase):
 
     def test_anthropic_provider_implementation(self):
         """Test Anthropic provider implementation."""
-        with patch('anthropic.Anthropic') as mock_anthropic:
+        with patch('testpilot.llm_providers.anthropic.Anthropic') as mock_anthropic:
             # Mock the Anthropic client
             mock_client = MagicMock()
             mock_response = MagicMock()


### PR DESCRIPTION
Fix `ModuleNotFoundError` in Anthropic tests by correcting the mock path and adding `anthropic` to project dependencies.

The `ModuleNotFoundError` occurred because the test was trying to patch `anthropic.Anthropic` directly, but the `AnthropicProvider` class imports `anthropic` at `testpilot.llm_providers.anthropic`. The patch target was updated to reflect the correct import location. Additionally, `anthropic` was added to `pyproject.toml` to ensure the dependency is properly declared for the project.